### PR TITLE
CP-14788: PCI device 0001 not 0002

### DIFF
--- a/create_templates.ml
+++ b/create_templates.ml
@@ -75,6 +75,9 @@ let disks_key = "disks"
 (** The key name pointing to the post-install script *)
 let post_install_key = "postinstall"
 
+(** The Xen Platform PCI Device [5853:0001] *)
+let xen_device_id = "0001"
+
 (** This type should never be modified. If you want to extend it, then
     we should do this some other way e.g. by using VDI.create directly. *)
 type disk = { device: string; (** device inside the guest eg xvda *)
@@ -489,7 +492,7 @@ let hvm_linux_template
     @ (["vga","std";"videoram","8"])
     @ [nx_flag]
     @ (["viridian", "false"])
-    @ ([ "device_id", "0001" ])
+    @ ([ "device_id", xen_device_id ])
   in
   let max_memory_gib = to_gib max_memory in
   {

--- a/create_templates.ml
+++ b/create_templates.ml
@@ -654,26 +654,26 @@ let create_all_templates rpc session_id =
 	[
 		other_install_media_template (default_memory_parameters 128L);
 		hvm_template "Windows XP SP3"             X32  256 16   4 [    v; ] "";
-		hvm_template "Windows Vista"              X32 1024 24   4 [n;  v;u] "0002";
-		hvm_template "Windows 7"                  X32 1024 24   4 [n;  v;u] "0002";
-		hvm_template "Windows 7"                  X64 2048 24 128 [n;  v;u] "0002";
-		hvm_template "Windows 8"                  ~generation_id:true X32 1024 24   4 [n;v;s;u] "0002";
-		hvm_template "Windows 8"                  ~generation_id:true X64 2048 24 128 [n;v;s;u] "0002";
-		hvm_template "Windows 10"                 ~generation_id:true X32 1024 24   4 [n;v;s;u] "0002";
-		hvm_template "Windows 10"                 ~generation_id:true X64 2048 24 128 [n;v;s;u] "0002";
+		hvm_template "Windows Vista"              X32 1024 24   4 [n;  v;u] xen_device_id;
+		hvm_template "Windows 7"                  X32 1024 24   4 [n;  v;u] xen_device_id;
+		hvm_template "Windows 7"                  X64 2048 24 128 [n;  v;u] xen_device_id;
+		hvm_template "Windows 8"                  ~generation_id:true X32 1024 24   4 [n;v;s;u] xen_device_id;
+		hvm_template "Windows 8"                  ~generation_id:true X64 2048 24 128 [n;v;s;u] xen_device_id;
+		hvm_template "Windows 10"                 ~generation_id:true X32 1024 24   4 [n;v;s;u] xen_device_id;
+		hvm_template "Windows 10"                 ~generation_id:true X64 2048 24 128 [n;v;s;u] xen_device_id;
 		hvm_template "Windows Server 2003"        X32  256 16  64 [    v; ] "";
 		hvm_template "Windows Server 2003"        X32  256 16  64 [  x;v; ] "";
 		hvm_template "Windows Server 2003"        X64  256 16 128 [n;  v; ] "";
 		hvm_template "Windows Server 2003"        X64  256 16 128 [n;x;v; ] "";
-		hvm_template "Windows Server 2008"        X32  512 24  64 [n;  v;u] "0002";
-		hvm_template "Windows Server 2008"        X32  512 24  64 [n;x;v;u] "0002";
-		hvm_template "Windows Server 2008"        X64  512 24 128 [n;  v;u] "0002";
-		hvm_template "Windows Server 2008"        X64  512 24 128 [n;x;v;u] "0002";
-		hvm_template "Windows Server 2008 R2"     X64  512 24 128 [n;  v;u] "0002";
-		hvm_template "Windows Server 2008 R2"     X64  512 24 128 [n;x;v;u] "0002";
-		hvm_template "Windows Server 2012"     	  ~generation_id:true X64 1024 32 128 [n;v;s;u] "0002";
-		hvm_template "Windows Server 2012 R2"     ~generation_id:true X64 1024 32 128 [n;v;s;u] "0002";
-		hvm_template "Windows Server 10 Preview"  ~is_experimental:true ~generation_id:true X64 1024 32 128 [n;v;s;u] "0002";
+		hvm_template "Windows Server 2008"        X32  512 24  64 [n;  v;u] xen_device_id;
+		hvm_template "Windows Server 2008"        X32  512 24  64 [n;x;v;u] xen_device_id;
+		hvm_template "Windows Server 2008"        X64  512 24 128 [n;  v;u] xen_device_id;
+		hvm_template "Windows Server 2008"        X64  512 24 128 [n;x;v;u] xen_device_id;
+		hvm_template "Windows Server 2008 R2"     X64  512 24 128 [n;  v;u] xen_device_id;
+		hvm_template "Windows Server 2008 R2"     X64  512 24 128 [n;x;v;u] xen_device_id;
+		hvm_template "Windows Server 2012"     	  ~generation_id:true X64 1024 32 128 [n;v;s;u] xen_device_id;
+		hvm_template "Windows Server 2012 R2"     ~generation_id:true X64 1024 32 128 [n;v;s;u] xen_device_id;
+		hvm_template "Windows Server 10 Preview"  ~is_experimental:true ~generation_id:true X64 1024 32 128 [n;v;s;u] xen_device_id;
 	] in
 
 	(* put default_template key in static_templates other_config of static_templates: *)


### PR DESCRIPTION
Those Windows templates that had "0002" for device_id in their
platform map are now given xen_device_id (i.e. "0001") instead.

Therefore the VMs will have emulated PCI device `5853:0001` (the
Xen Platform Device) rather than emulated PCI device `5853:0002`
(which Windows identifies as the "Citrix PV bus").