### PR TITLE
CP-15214: Windows: device 0002 not 0001 after all.

### DIFF
--- a/create_templates.ml
+++ b/create_templates.ml
@@ -78,6 +78,8 @@ let post_install_key = "postinstall"
 (** The Xen Platform PCI Device [5853:0001] *)
 let xen_device_id = "0001"
 
+let xenSERVER_device_id = "0002"
+
 (** This type should never be modified. If you want to extend it, then
     we should do this some other way e.g. by using VDI.create directly. *)
 type disk = { device: string; (** device inside the guest eg xvda *)
@@ -655,26 +657,26 @@ let create_all_templates rpc session_id =
 	[
 		other_install_media_template (default_memory_parameters 128L);
 		hvm_template "Windows XP SP3"             X32  256 16   4 [    v; ] "";
-		hvm_template "Windows Vista"              X32 1024 24   4 [n;  v;d] xen_device_id;
-		hvm_template "Windows 7"                  X32 1024 24   4 [n;  v;d] xen_device_id;
-		hvm_template "Windows 7"                  X64 2048 24 128 [n;  v;d] xen_device_id;
-		hvm_template "Windows 8"                  ~generation_id:true X32 1024 24   4 [n;v;s;d] xen_device_id;
-		hvm_template "Windows 8"                  ~generation_id:true X64 2048 24 128 [n;v;s;d] xen_device_id;
-		hvm_template "Windows 10"                 ~generation_id:true X32 1024 24   4 [n;v;s;d] xen_device_id;
-		hvm_template "Windows 10"                 ~generation_id:true X64 2048 24 128 [n;v;s;d] xen_device_id;
+		hvm_template "Windows Vista"              X32 1024 24   4 [n;  v;d] xenSERVER_device_id;
+		hvm_template "Windows 7"                  X32 1024 24   4 [n;  v;d] xenSERVER_device_id;
+		hvm_template "Windows 7"                  X64 2048 24 128 [n;  v;d] xenSERVER_device_id;
+		hvm_template "Windows 8"                  ~generation_id:true X32 1024 24   4 [n;v;s;d] xenSERVER_device_id;
+		hvm_template "Windows 8"                  ~generation_id:true X64 2048 24 128 [n;v;s;d] xenSERVER_device_id;
+		hvm_template "Windows 10"                 ~generation_id:true X32 1024 24   4 [n;v;s;d] xenSERVER_device_id;
+		hvm_template "Windows 10"                 ~generation_id:true X64 2048 24 128 [n;v;s;d] xenSERVER_device_id;
 		hvm_template "Windows Server 2003"        X32  256 16  64 [    v; ] "";
 		hvm_template "Windows Server 2003"        X32  256 16  64 [  x;v; ] "";
 		hvm_template "Windows Server 2003"        X64  256 16 128 [n;  v; ] "";
 		hvm_template "Windows Server 2003"        X64  256 16 128 [n;x;v; ] "";
-		hvm_template "Windows Server 2008"        X32  512 24  64 [n;  v;d] xen_device_id;
-		hvm_template "Windows Server 2008"        X32  512 24  64 [n;x;v;d] xen_device_id;
-		hvm_template "Windows Server 2008"        X64  512 24 1000 [n;  v;d] xen_device_id;
-		hvm_template "Windows Server 2008"        X64  512 24 1000 [n;x;v;d] xen_device_id;
-		hvm_template "Windows Server 2008 R2"     X64  512 24 1500 [n;  v;d] xen_device_id;
-		hvm_template "Windows Server 2008 R2"     X64  512 24 1500 [n;x;v;d] xen_device_id;
-		hvm_template "Windows Server 2012"     	  ~generation_id:true X64 1024 32 1500 [n;v;s;d] xen_device_id;
-		hvm_template "Windows Server 2012 R2"     ~generation_id:true X64 1024 32 1500 [n;v;s;d] xen_device_id;
-		hvm_template "Windows Server 10 Preview"  ~is_experimental:true ~generation_id:true X64 1024 32 1500 [n;v;s;d] xen_device_id;
+		hvm_template "Windows Server 2008"        X32  512 24  64 [n;  v;d] xenSERVER_device_id;
+		hvm_template "Windows Server 2008"        X32  512 24  64 [n;x;v;d] xenSERVER_device_id;
+		hvm_template "Windows Server 2008"        X64  512 24 1000 [n;  v;d] xenSERVER_device_id;
+		hvm_template "Windows Server 2008"        X64  512 24 1000 [n;x;v;d] xenSERVER_device_id;
+		hvm_template "Windows Server 2008 R2"     X64  512 24 1500 [n;  v;d] xenSERVER_device_id;
+		hvm_template "Windows Server 2008 R2"     X64  512 24 1500 [n;x;v;d] xenSERVER_device_id;
+		hvm_template "Windows Server 2012"     	  ~generation_id:true X64 1024 32 1500 [n;v;s;d] xenSERVER_device_id;
+		hvm_template "Windows Server 2012 R2"     ~generation_id:true X64 1024 32 1500 [n;v;s;d] xenSERVER_device_id;
+		hvm_template "Windows Server 10 Preview"  ~is_experimental:true ~generation_id:true X64 1024 32 1500 [n;v;s;d] xenSERVER_device_id;
 	] in
 
 	(* put default_template key in static_templates other_config of static_templates: *)


### PR DESCRIPTION
This reverses the spirit of CP-14788: it turns out that the Windows
templates still need the 0002 PCI device rather than 0001.

According to Paul Durrant,
"Apparently PVS expects that it is possible to take a disk image
from a VM provisioned on one version of XenServer and use it on a VM
running on another version of XenServer. This basically means that
we can never modify the virtual hardware platform, only add to it."